### PR TITLE
Add support for specifying an alternate theme for Sphinx to use.

### DIFF
--- a/bin/sphinx-view
+++ b/bin/sphinx-view
@@ -43,17 +43,31 @@ if __name__ == '__main__':
         """,
         )
     parser.add_argument(
+        '-t',
+        '--theme',
+        help="""
+            Set the theme to use when building docs.
+            Defaults to alabaster.
+        """,
+        )
+    parser.add_argument(
         'target',
         help='The target to view',
     )
     args = parser.parse_args()
     print(args.target)
 
+    if args.theme is not None:
+        theme = args.theme
+    else:
+        theme = 'alabaster'
+
     config = dict(
         TARGET=expand_path(args.target),
         SERVER_PORT=args.port,
         PACKAGE=args.package,
         PACKAGE_DOCS=args.package_docs,
+        THEME=theme,
     )
 
     if args.build_dir is not None:

--- a/bin/sphinx-view
+++ b/bin/sphinx-view
@@ -49,6 +49,7 @@ if __name__ == '__main__':
             Set the theme to use when building docs.
             Defaults to alabaster.
         """,
+        default='alabaster',
         )
     parser.add_argument(
         'target',
@@ -57,17 +58,12 @@ if __name__ == '__main__':
     args = parser.parse_args()
     print(args.target)
 
-    if args.theme is not None:
-        theme = args.theme
-    else:
-        theme = 'alabaster'
-
     config = dict(
         TARGET=expand_path(args.target),
         SERVER_PORT=args.port,
         PACKAGE=args.package,
         PACKAGE_DOCS=args.package_docs,
-        THEME=theme,
+        THEME=args.theme,
     )
 
     if args.build_dir is not None:

--- a/sview/builder.py
+++ b/sview/builder.py
@@ -21,6 +21,7 @@ class Builder:
         self.package = config.get('PACKAGE')
         self.package_docs = config.get('PACKAGE_DOCS', 'docs')
         self.build_dir = os.path.join(self.working_dir, 'build')
+        self.theme = config.get('THEME')
 
         if logger is None:
             self.logger = logging.getLogger(__name__)
@@ -89,11 +90,12 @@ class Builder:
         conf_content = textwrap.dedent("""
             source_suffix = '{ext}'
             master_doc = 'index'
-            html_theme = 'alabaster'
+            html_theme = '{theme}'
             html_static_path = ['_static']
             extensions = ['sphinx.ext.autodoc']
         """).format(
             ext=self.fetch_ext_from_index(),
+            theme=self.theme,
         )
 
         with open(final_conf_path, 'w') as conf_file:


### PR DESCRIPTION
Howdy,

We use the "sphinx_rtd_theme" in our docs and I'd like to have sphinx-view to use that theme rather than the default "alabaster" theme.  So I've added support for specifying a theme via the command line and then having sphinx-view use that theme when running.

The specified sphinx theme still needs to be installed prior to running sphinx-view.

Let me know if you think you can include this in the main code.

Thanks