### PR TITLE
Add support for specifying Sphinx extensions via command line.

### DIFF
--- a/bin/sphinx-view
+++ b/bin/sphinx-view
@@ -43,6 +43,15 @@ if __name__ == '__main__':
         """,
         )
     parser.add_argument(
+        '-e',
+        '--extensions',
+        help="""
+            Set to a comma separated list of Sphinx extensions to enable.
+            Defaults to sphinx.ext.autodoc.
+        """,
+        default='sphinx.ext.autodoc',
+        )
+    parser.add_argument(
         'target',
         help='The target to view',
     )
@@ -54,6 +63,7 @@ if __name__ == '__main__':
         SERVER_PORT=args.port,
         PACKAGE=args.package,
         PACKAGE_DOCS=args.package_docs,
+        EXTENSIONS=args.extensions.split(','),
     )
 
     if args.build_dir is not None:

--- a/sview/builder.py
+++ b/sview/builder.py
@@ -21,6 +21,7 @@ class Builder:
         self.package = config.get('PACKAGE')
         self.package_docs = config.get('PACKAGE_DOCS', 'docs')
         self.build_dir = os.path.join(self.working_dir, 'build')
+        self.extensions = config.get('EXTENSIONS')
 
         if logger is None:
             self.logger = logging.getLogger(__name__)
@@ -91,9 +92,10 @@ class Builder:
             master_doc = 'index'
             html_theme = 'alabaster'
             html_static_path = ['_static']
-            extensions = ['sphinx.ext.autodoc']
+            extensions = {extensions}
         """).format(
             ext=self.fetch_ext_from_index(),
+            extensions=self.extensions,
         )
 
         with open(final_conf_path, 'w') as conf_file:


### PR DESCRIPTION
Needed to have additional sphinx extensions enabled in order to verify our docs are building correctly.

Added --extensions command line argument to allow the user to specify a comma separated list of sphinx extensions to have enabled during the sphinx-view run.