### PR TITLE
Allow a specific sphinx conf.py to be used.

### DIFF
--- a/.project_metadata.json
+++ b/.project_metadata.json
@@ -5,6 +5,6 @@
     "description": "View your rendered Sphinx or ReStructuredText documents in a browser",
     "license": "MIT",
     "name": "sphinx-view",
-    "release": "0.1.3",
+    "release": "0.1.3.post1",
     "version": "0.1"
 }

--- a/.project_metadata.json
+++ b/.project_metadata.json
@@ -5,6 +5,6 @@
     "description": "View your rendered Sphinx or ReStructuredText documents in a browser",
     "license": "MIT",
     "name": "sphinx-view",
-    "release": "0.1.3.post1",
+    "release": "0.1.3",
     "version": "0.1"
 }

--- a/bin/sphinx-view
+++ b/bin/sphinx-view
@@ -43,22 +43,13 @@ if __name__ == '__main__':
         """,
         )
     parser.add_argument(
-        '-t',
-        '--theme',
+        '-c',
+        '--config',
         help="""
-            Set the theme to use when building docs.
-            Defaults to alabaster.
+            Set the config file to use when building docs.
+            Defaults to an internal hard-coded basic sphinx config.
         """,
-        default='alabaster',
-        )
-    parser.add_argument(
-        '-e',
-        '--extensions',
-        help="""
-            Set to a comma separated list of Sphinx extensions to enable.
-            Defaults to sphinx.ext.autodoc.
-        """,
-        default='sphinx.ext.autodoc',
+        default=None,
         )
     parser.add_argument(
         'target',
@@ -72,8 +63,7 @@ if __name__ == '__main__':
         SERVER_PORT=args.port,
         PACKAGE=args.package,
         PACKAGE_DOCS=args.package_docs,
-        THEME=args.theme,
-        EXTENSIONS=args.extensions.split(','),
+        CONFIG=args.config,
     )
 
     if args.build_dir is not None:

--- a/bin/sphinx-view
+++ b/bin/sphinx-view
@@ -43,17 +43,31 @@ if __name__ == '__main__':
         """,
         )
     parser.add_argument(
+        '-t',
+        '--theme',
+        help="""
+            Set the theme to use when building docs.
+            Defaults to alabaster.
+        """,
+        )
+    parser.add_argument(
         'target',
         help='The target to view',
     )
     args = parser.parse_args()
     print(args.target)
 
+    if args.theme is not None:
+        theme = args.theme
+    else:
+        theme = 'alabaster'
+
     config = dict(
         TARGET=expand_path(args.target),
         SERVER_PORT=args.port,
         PACKAGE=args.package,
         PACKAGE_DOCS=args.package_docs,
+        THEME=theme,
     )
 
     if args.build_dir is not None:

--- a/bin/sphinx-view
+++ b/bin/sphinx-view
@@ -49,6 +49,7 @@ if __name__ == '__main__':
             Set the theme to use when building docs.
             Defaults to alabaster.
         """,
+        default='alabaster',
         )
     parser.add_argument(
         'target',
@@ -57,17 +58,12 @@ if __name__ == '__main__':
     args = parser.parse_args()
     print(args.target)
 
-    if args.theme is not None:
-        theme = args.theme
-    else:
-        theme = 'alabaster'
-
     config = dict(
         TARGET=expand_path(args.target),
         SERVER_PORT=args.port,
         PACKAGE=args.package,
         PACKAGE_DOCS=args.package_docs,
-        THEME=theme,
+        THEME=args.theme,
     )
 
     if args.build_dir is not None:

--- a/bin/sphinx-view
+++ b/bin/sphinx-view
@@ -43,6 +43,15 @@ if __name__ == '__main__':
         """,
         )
     parser.add_argument(
+        '-e',
+        '--extensions',
+        help="""
+            Set to a comma separated list of Sphinx extensions to enable.
+            Defaults to sphinx.ext.autodoc.
+        """,
+        default='sphinx.ext.autodoc',
+        )
+    parser.add_argument(
         'target',
         help='The target to view',
     )
@@ -54,6 +63,7 @@ if __name__ == '__main__':
         SERVER_PORT=args.port,
         PACKAGE=args.package,
         PACKAGE_DOCS=args.package_docs,
+        EXTENSIONS=args.extensions.split(','),
     )
 
     if args.build_dir is not None:

--- a/sview/builder.py
+++ b/sview/builder.py
@@ -21,8 +21,7 @@ class Builder:
         self.package = config.get('PACKAGE')
         self.package_docs = config.get('PACKAGE_DOCS', 'docs')
         self.build_dir = os.path.join(self.working_dir, 'build')
-        self.theme = config.get('THEME')
-        self.extensions = config.get('EXTENSIONS')
+        self.config = config.get('CONFIG', None)
 
         if logger is None:
             self.logger = logging.getLogger(__name__)
@@ -88,17 +87,19 @@ class Builder:
 
     def build_conf_file(self):
         final_conf_path = os.path.join(self.build_dir, 'conf.py')
-        conf_content = textwrap.dedent("""
-            source_suffix = '{ext}'
-            master_doc = 'index'
-            html_theme = '{theme}'
-            html_static_path = ['_static']
-            extensions = {extensions}
-        """).format(
-            ext=self.fetch_ext_from_index(),
-            theme=self.theme,
-            extensions=self.extensions,
-        )
+        if self.config is None:
+            conf_content = textwrap.dedent("""
+                source_suffix = '{ext}'
+                master_doc = 'index'
+                html_theme = 'alabaster'
+                html_static_path = ['_static']
+                extensions = ['sphinx.ext.autodoc']
+            """).format(
+                ext=self.fetch_ext_from_index(),
+            )
+        else:
+            with open(self.config, 'r') as fconfig:
+                conf_content = fconfig.read()
 
         with open(final_conf_path, 'w') as conf_file:
             conf_file.write(conf_content)

--- a/sview/builder.py
+++ b/sview/builder.py
@@ -21,6 +21,7 @@ class Builder:
         self.package = config.get('PACKAGE')
         self.package_docs = config.get('PACKAGE_DOCS', 'docs')
         self.build_dir = os.path.join(self.working_dir, 'build')
+        self.extensions = config.get('EXTENSIONS')
 
         if logger is None:
             self.logger = logging.getLogger(__name__)
@@ -91,9 +92,10 @@ class Builder:
             master_doc = 'index'
             html_theme = 'alabaster'
             html_static_path = ['_static']
-            extensions = ['sphinx.ext.autodoc']
+            extensions = {extensions}
         """).format(
             ext=self.fetch_ext_from_index(),
+            extensions=self.extensions,
         )
 
         with open(final_conf_path, 'w') as conf_file:

--- a/sview/builder.py
+++ b/sview/builder.py
@@ -21,6 +21,7 @@ class Builder:
         self.package = config.get('PACKAGE')
         self.package_docs = config.get('PACKAGE_DOCS', 'docs')
         self.build_dir = os.path.join(self.working_dir, 'build')
+        self.theme = config.get('THEME')
 
         if logger is None:
             self.logger = logging.getLogger(__name__)
@@ -89,11 +90,12 @@ class Builder:
         conf_content = textwrap.dedent("""
             source_suffix = '{ext}'
             master_doc = 'index'
-            html_theme = 'alabaster'
+            html_theme = '{theme}'
             html_static_path = ['_static']
             extensions = ['sphinx.ext.autodoc']
         """).format(
             ext=self.fetch_ext_from_index(),
+            theme=self.theme,
         )
 
         with open(final_conf_path, 'w') as conf_file:


### PR DESCRIPTION
This PR added a command-line arg named "--config"  that accepts a sphinx conf.py file.

The expectation is that sphinx-view is run inside a virtual environment for a project that already has sphinx installed and configured. This allows sphinx-view to use any sphinx extensions that have been installed and configured in the virtual environment.

If sphinx-view is being used "outside" of a project's virtual environment, then extension support may be unpredictable or broken. Let me know if you have ideas or a point of view on how you want to approach this situation. (I *always* use sphinx-view in the same VE as the project docs)